### PR TITLE
Support to exclude from navigation

### DIFF
--- a/sc/contentrules/groupbydate/actions/groupbydate.py
+++ b/sc/contentrules/groupbydate/actions/groupbydate.py
@@ -180,7 +180,11 @@ class GroupByDateActionExecutor(MoveActionExecutor):
             elif structure == 'y':
                 dateFormat = '%Y'
         else:
-            dateFormat = structure
+            # Create a list stating if the folder should be hiddden from 
+            # navigation
+            should_exclude = ['ee' in i for i in structure.split('/')]
+            # Now remove all the 'h' that may be in the structure
+            dateFormat = structure.replace('ee','')
 
         date = date.strftime(dateFormat)
 
@@ -188,13 +192,15 @@ class GroupByDateActionExecutor(MoveActionExecutor):
 
         container = self.element.container
         default_view = self.element.default_view
-        for fId in folderStructure:
+        for (fId, exclude) in zip(folderStructure, should_exclude):
             if not fId in folder.objectIds():
                 _createObjectByType(container, folder, id=fId,
                                     title=fId, description=fId)
                 folder = folder[fId]
                 folder.setLayout(default_view)
                 self._addWorkflowPolicy(folder)
+                if exclude:
+                    folder.setExcludeFromNav(True)
             else:
                 folder = folder[fId]
         return folder

--- a/sc/contentrules/groupbydate/tests/test_action_groupbydate.py
+++ b/sc/contentrules/groupbydate/tests/test_action_groupbydate.py
@@ -343,6 +343,30 @@ class TestGroupByDateAction(unittest.TestCase):
                                                           e.base_folder[1:])
         self.failUnless('cmf' in target_folder.objectIds())
 
+    def testExcludeFolderFromNav(self):
+        ''' Execute the action specifying some folders that should be
+            excluded from navigation
+        '''
+        e = GroupByDateAction()
+        e.base_folder = '/target'
+        e.structure = '%Yee/%m/%dee'
+        e.container = 'Folder'
 
+        ex = getMultiAdapter((self.folder, e, DummyEvent(self.folder.d1)),
+                             IExecutable)
+        self.assertEquals(True, ex())
+
+        foldera = self.portal.unrestrictedTraverse('%s/2009' %
+                                                         e.base_folder[1:])
+        folderb = self.portal.unrestrictedTraverse('%s/2009/04' %
+                                                         e.base_folder[1:])
+        folderc = self.portal.unrestrictedTraverse('%s/2009/04/22' %
+                                                         e.base_folder[1:])
+
+        self.assertTrue(foldera.exclude_from_nav())
+        self.assertFalse(folderb.exclude_from_nav())
+        self.assertTrue(folderc.exclude_from_nav())
+        
+        
 def test_suite():
      return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
When defining the folder structure, you can add "ee" to specify that you want that folder to be excluded from navigation.

e.g.
%Yee/%m/%dee

will create a folder with the year (excluded), month (not excluded) and day (excluded)

I decided to use 2 'e', to not interfere with any possible strptime format, or any folder name you would like to use, except of course, your folder name has 2 'e'...
